### PR TITLE
Fix GitHub Actions workflow - update deprecated actions

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -55,7 +55,7 @@ jobs:
           sudo gem install html-proofer
           htmlproofer public --allow-hash-href --check-html --empty-alt-ignore --disable-external
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ./public
 
@@ -69,4 +69,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v3
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
- Update actions/upload-pages-artifact from v2 to v3
- Update actions/deploy-pages from v3 to v4
- Resolve deprecation warnings for artifact actions